### PR TITLE
Italian: reverted wrong translation for "upscale"

### DIFF
--- a/resources/it/cemu.po
+++ b/resources/it/cemu.po
@@ -515,7 +515,7 @@ msgstr "&Pack grafici"
 
 #: MainWindow.cpp:1993
 msgid "&Upscale filter"
-msgstr "&Filtro di ridimensione"
+msgstr "&Filtro di upscaling"
 
 #: MainWindow.cpp:1994
 msgid "&Fullscreen scaling"


### PR DESCRIPTION
An exact literal translation for upscale/upscaling doesn't exist in Italian; [it.wikipedia.org](https://it.wikipedia.org/wiki/Upscaling) uses the term 'upscaling' too. "ridimensione" is not even a correct Italian word, afaik.
Furthermore, I'd like to discuss about some other things edited with #4 in a specific issue.